### PR TITLE
Fix hack for go agent user name

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -10,8 +10,8 @@ VOLUME /var/go
 # keep image updated
 RUN apt-get update && apt-get upgrade -y
 
-# create a 'worker' user for, and avoid automatic user creation by go
-RUN useradd -u 909 -d $HOME -M -s /bin/bash worker
+# create a 'go' user for, and avoid automatic user creation by go
+RUN useradd -u 909 -d $HOME -M -s /bin/bash go
 
 # install Go debian package
 COPY *.deb /


### PR DESCRIPTION
Have to fix username hack to avoid user id conflicts.

We need this because currently go agent uses `go` as user name.