### PR TITLE
39 upgrade toolchains

### DIFF
--- a/toolchains/build-versions.sh
+++ b/toolchains/build-versions.sh
@@ -2,7 +2,7 @@ TOOLCHAINS="
 leiningen:7
 maven:3-6
 nodejs:6.1-2
-python:3.5-2
+python:3.5-8
 stups:21
 golang:10
 "

--- a/toolchains/build-versions.sh
+++ b/toolchains/build-versions.sh
@@ -1,8 +1,8 @@
 TOOLCHAINS="
-leiningen:5
-maven:3-5
-nodejs:6.1-1
-python:3.5-1
-stups:19
-golang:9
+leiningen:7
+maven:3-6
+nodejs:6.1-2
+python:3.5-2
+stups:21
+golang:10
 "

--- a/toolchains/build-versions.sh
+++ b/toolchains/build-versions.sh
@@ -1,8 +1,8 @@
 TOOLCHAINS="
 leiningen:7
 maven:3-6
-nodejs:6.1-2
-python:3.5-8
+nodejs:6.1-3
+python:3.5-9
 stups:21
 golang:10
 "

--- a/toolchains/golang.dockerfile
+++ b/toolchains/golang.dockerfile
@@ -1,12 +1,12 @@
-FROM registry.opensource.zalan.do/stups/ubuntu:16.04-35
+FROM registry.opensource.zalan.do/stups/ubuntu:16.04-41
 
 RUN apt-get update && apt-get install -y git make
 
-RUN curl https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz -o /tmp/go1.6.1.linux-amd64.tar.gz && \
-    echo '6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988 /tmp/go1.6.1.linux-amd64.tar.gz' > /tmp/go1.6.1.linux-amd64.tar.gz.sha256sum && \
-    sha256sum --check /tmp/go1.6.1.linux-amd64.tar.gz.sha256sum && \
-    tar -C /usr/local -xzf /tmp/go1.6.1.linux-amd64.tar.gz && \
-    rm /tmp/go1.6.1.linux-amd64.tar.gz
+RUN curl https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz -o /tmp/go1.7.linux-amd64.tar.gz && \
+    echo '702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95 /tmp/go1.7.linux-amd64.tar.gz' > /tmp/go1.7.linux-amd64.tar.gz.sha256sum && \
+    sha256sum --check /tmp/go1.7.linux-amd64.tar.gz.sha256sum && \
+    tar -C /usr/local -xzf /tmp/go1.7.linux-amd64.tar.gz && \
+    rm /tmp/go1.7.linux-amd64.tar.gz
 
 
 # keep our environment even after doing "su"

--- a/toolchains/leiningen.dockerfile
+++ b/toolchains/leiningen.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-28
+FROM registry.opensource.zalan.do/stups/openjdk:8-34
 
 RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > /usr/local/bin/lein \
         && chmod +x /usr/local/bin/lein

--- a/toolchains/maven.dockerfile
+++ b/toolchains/maven.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-28
+FROM registry.opensource.zalan.do/stups/openjdk:8-34
 
 RUN apt-get update && apt-get install -y maven bzip2
 

--- a/toolchains/nodejs.dockerfile
+++ b/toolchains/nodejs.dockerfile
@@ -1,7 +1,7 @@
 FROM registry.opensource.zalan.do/stups/node:6.4-42
 
 # general tools
-RUN apt-get install -y git
+RUN apt-get update && apt-get install -y git
 
 COPY switch-user.sh /switch-user.sh
 ENTRYPOINT ["/switch-user.sh"]

--- a/toolchains/nodejs.dockerfile
+++ b/toolchains/nodejs.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/node:6.1-30
+FROM registry.opensource.zalan.do/stups/node:6.4-42
 
 # general tools
 RUN apt-get install -y git

--- a/toolchains/python.dockerfile
+++ b/toolchains/python.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/python:3.5.1-23
+FROM registry.opensource.zalan.do/stups/python:3.5.1-29
 
 RUN apt-get update && apt-get install -y git build-essential libxml2-dev libxslt-dev zlib1g-dev
 

--- a/toolchains/stups.dockerfile
+++ b/toolchains/stups.dockerfile
@@ -1,7 +1,7 @@
-FROM registry.opensource.zalan.do/stups/python:3.5.1-23
-
-RUN apt-get update && apt-get install -y jq git sudo
-RUN pip3 install stups scm-source awscli lizzy-client
+FROM registry.opensource.zalan.do/stups/python:3.5.1-29
+# in favor of getting the cryptography python package installed we have to install libssl-dev and libffi-dev first
+RUN apt-get update && apt-get install -y libssl-dev libffi-dev jq git sudo
+RUN pip3 install stups scm-source awscli
 
 RUN curl -L https://github.com/jwilder/docker-squash/releases/download/v0.2.0/docker-squash-linux-amd64-v0.2.0.tar.gz -o /tmp/docker-squash.tar.gz \
     && tar -C /usr/local/bin -xzvf /tmp/docker-squash.tar.gz \


### PR DESCRIPTION
updates the toolchains:
* base-images
* software versions like newest golang SDK
* removed lizzy-client from STUPS toolchain because of a bug making senza unusable