### PR TITLE
Made resources configurable via environment variable

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -11,6 +11,7 @@ chown -R go:go /var/go
 # setup auto registration
 echo "agent.auto.register.key=$STUPS_GO_AGENT_REGISTRATION_KEY" >> /var/lib/go-agent/config/autoregister.properties
 echo "agent.auto.register.environments=$STUPS_GO_AGENT_ENVIRONMENTS" >> /var/lib/go-agent/config/autoregister.properties
+echo "agent.auto.register.resources=$STUPS_GO_AGENT_RESOURCES" >> /var/lib/go-agent/config/autoregister.properties
 
 # extract deploment files
 su go -c /extract-files.sh


### PR DESCRIPTION
Since it is possible to select the agents via job resources as well, this should be supported for auto register the deployed agents.

This relates to the issue #42 

@sarnowski Could you please review it?
