### PR TITLE
Enabled gocd users to authenticate via GitHub enterprise

### DIFF
--- a/prepare-deps.sh
+++ b/prepare-deps.sh
@@ -4,7 +4,7 @@
 FILES="
 https://download.go.cd/binaries/16.2.1-3027/deb/go-server-16.2.1-3027.deb>c80edfccbd42a37ffbe554fcac4c21c9>dd3381a0e73c4aba34e328674e97ace50958c208>server
 https://download.go.cd/binaries/16.2.1-3027/deb/go-agent-16.2.1-3027.deb>1e9c21f12e1fd41f36e157f86b113e29>d72f8e314499e69dfd56741a866f08cfa695def2>agent
-https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v1.2/github-oauth-login-1.2.jar>31ad9ad1fe08452f73c56a44b035ee91>1bea6bb7da660544c1a4686e7ecf5d7c556e5fcd>server
+https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.2/github-oauth-login-2.2.jar>27fbec946a3be22b7c8ab1153da43f5a>5dbce4fa0772de61dcc34c05b70e0719ecb79c0b>server
 "
 for f in $FILES; do
 	url=$(echo $f | cut -d'>' -f1)

--- a/server/run.sh
+++ b/server/run.sh
@@ -27,6 +27,7 @@ echo "export SERVER_MAX_MEM=\$(java-dynamic-memory-opts)" >> /etc/default/go-ser
 
 # enable custom extensions
 mkdir -p /data/plugins/external
+rm -f /data/plugins/external/github-oauth-login-1.2.jar
 cp /*.jar /data/plugins/external
 
 # ensuring perimssions


### PR DESCRIPTION
This PR updates the version of the github-oauth-login plugin. In this new Version are my PR's included which enables the gocd users to be authenticated via enterprise GitHub or  public GitHub.

While testing this Version on our GoCD instance I figured out one problem with updating the plugin. Just placing the new plugin doesn't remove the old one and GoCD doesn't detect the newer one automatically.

@sarnowski What do you think how to fix this problem? Currently I just added a removal of the old plugin to the run.sh script.

The previous PR's to enable this:
https://github.com/gocd-contrib/gocd-oauth-login/pull/40
https://github.com/3pillarlabs/socialauth/pull/95